### PR TITLE
Make Collections Enumerable.

### DIFF
--- a/lib/sheet_mapper/collection.rb
+++ b/lib/sheet_mapper/collection.rb
@@ -1,7 +1,9 @@
+require 'delegate'
+
 module SheetMapper
   class CollectionNotFound < StandardError; end
 
-  class Collection
+  class Collection < SimpleDelegator
     attr_reader :records, :worksheet
 
     # spreadsheet is a SheetMapper::Spreadsheet
@@ -11,12 +13,6 @@ module SheetMapper
       @worksheet   = worksheet
       @mapper      = @spreadsheet.mapper
       @records     = process_records!
-    end
-
-    # Each block for every mapped record
-    # @collection.each { |m| ...mapped obj... }
-    def each(&block)
-      records.each(&block)
     end
 
     # Returns an array of mapped records
@@ -43,6 +39,10 @@ module SheetMapper
     def reload
       @worksheet.reload
       @records = process_records!
+    end
+
+    def __getobj__
+      @records
     end
 
     protected

--- a/test/collection_test.rb
+++ b/test/collection_test.rb
@@ -33,20 +33,18 @@ describe "Collection" do
     end
   end # worksheet
 
-  context "for each method" do
-    setup do
+  context "Enumerability" do
+    subject do
       @collection = SheetMapper::Collection.new(@spreadsheet, @worksheet)
     end
 
-    should "support iterating each mapped row" do
-      rows = []
-      @collection.each { |c| rows << c }
-      assert_equal 3, rows.size
-      assert_equal ["Bob", 21], rows[0].tuple
-      assert_equal ["Susan", 34], rows[1].tuple
-      assert_equal ["Joey", 67], rows[2].tuple
+    should "behave like an Enumerable" do
+      assert_equal subject.first, subject.records.first
+      assert subject.respond_to?(:each)
+      assert subject.respond_to?(:find)
+      assert subject.respond_to?(:map)
     end
-  end # each
+  end # enum
 
   context "for rows method" do
     setup do


### PR DESCRIPTION
This uses delegation to call unknown Collection methods on the records attribute which allows the full use of all enumerable methods on a collection without re-implementing them by hand.
